### PR TITLE
style: enhance platform tabs

### DIFF
--- a/components/ui/PlatformTabs.tsx
+++ b/components/ui/PlatformTabs.tsx
@@ -11,18 +11,25 @@ const PlatformTabs: React.FC<PlatformTabsProps> = ({ platforms, selected, onSele
   if (platforms.length === 0) return null;
 
   return (
-    <div className="flex gap-2 overflow-x-auto pb-2">
-      {platforms.map(p => (
+    <div className="flex gap-3 overflow-x-auto pb-2">
+      {platforms.map((p) => (
         <button
           key={p.id}
           onClick={() => onSelect(p.id)}
-          className={`px-4 py-2 rounded-md text-sm font-medium border transition-colors duration-150 whitespace-nowrap ${
+          className={`flex items-center gap-2 px-4 py-2 rounded-lg border text-sm font-medium transition-all duration-150 whitespace-nowrap shadow-sm ${
             selected === p.id
-              ? 'bg-blue-600 text-white border-blue-600'
-              : 'bg-white text-slate-700 border-slate-300 hover:bg-slate-50'
+              ? 'bg-gradient-to-r from-blue-600 to-indigo-600 text-white border-transparent shadow'
+              : 'bg-white text-slate-700 border-slate-300 hover:bg-slate-50 hover:shadow'
           }`}
         >
-          {p.title}
+          <span
+            className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${
+              selected === p.id ? 'bg-white text-blue-600' : 'bg-blue-600 text-white'
+            }`}
+          >
+            {p.title.charAt(0).toUpperCase()}
+          </span>
+          <span>{p.title}</span>
         </button>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- Add gradient and avatar-style indicator to platform tabs for a more polished platform selector

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c809547b48832b9511fdd7e3cb760a