### PR TITLE
Allow updating agent expiration

### DIFF
--- a/components/ui/Select.tsx
+++ b/components/ui/Select.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  label?: string;
+}
+
+const Select: React.FC<SelectProps> = ({ label, id, children, className = '', ...props }) => {
+  return (
+    <div>
+      {label && (
+        <label htmlFor={id} className="block text-sm font-medium text-slate-700 mb-1.5">
+          {label}
+        </label>
+      )}
+      <select
+        id={id}
+        className={`block w-full px-3 py-2 bg-white border border-slate-300 rounded-md text-sm shadow-sm focus:outline-none focus:border-blue-500 focus:ring-1 focus:ring-blue-500 disabled:bg-slate-50 disabled:text-slate-500 disabled:border-slate-200 disabled:shadow-none ${className}`}
+        {...props}
+      >
+        {children}
+      </select>
+    </div>
+  );
+};
+
+export default Select;

--- a/hooks/useExpirationCountdown.ts
+++ b/hooks/useExpirationCountdown.ts
@@ -1,0 +1,74 @@
+import { useEffect, useMemo, useState } from 'react';
+
+const SECONDS_IN_MINUTE = 60;
+const SECONDS_IN_HOUR = SECONDS_IN_MINUTE * 60;
+const SECONDS_IN_DAY = SECONDS_IN_HOUR * 24;
+
+export const formatTimeLeft = (milliseconds: number): string => {
+  const totalSeconds = Math.max(0, Math.floor(milliseconds / 1000));
+  const days = Math.floor(totalSeconds / SECONDS_IN_DAY);
+  const hours = Math.floor((totalSeconds % SECONDS_IN_DAY) / SECONDS_IN_HOUR);
+  const minutes = Math.floor((totalSeconds % SECONDS_IN_HOUR) / SECONDS_IN_MINUTE);
+  const seconds = totalSeconds % SECONDS_IN_MINUTE;
+
+  const parts: string[] = [];
+  if (days > 0) {
+    parts.push(`${days} วัน`);
+  }
+  if (hours > 0 || days > 0) {
+    parts.push(`${hours} ชม.`);
+  }
+  if (minutes > 0 || hours > 0 || days > 0) {
+    parts.push(`${minutes} นาที`);
+  }
+  parts.push(`${seconds} วินาที`);
+
+  return parts.join(' ');
+};
+
+export const useExpirationCountdown = (expirationAt?: string) => {
+  const expirationDate = useMemo(() => {
+    if (!expirationAt) return null;
+    const parsed = new Date(expirationAt);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }, [expirationAt]);
+
+  const [timeLeft, setTimeLeft] = useState(() =>
+    expirationDate ? expirationDate.getTime() - Date.now() : 0
+  );
+
+  useEffect(() => {
+    if (!expirationDate) {
+      setTimeLeft(0);
+      return;
+    }
+
+    const updateTimeLeft = () => {
+      setTimeLeft(expirationDate.getTime() - Date.now());
+    };
+
+    updateTimeLeft();
+
+    if (expirationDate.getTime() <= Date.now()) {
+      return;
+    }
+
+    const intervalId = window.setInterval(updateTimeLeft, 1000);
+    return () => window.clearInterval(intervalId);
+  }, [expirationDate]);
+
+  const isExpired = expirationDate ? timeLeft <= 0 : false;
+  const formatted = useMemo(() => {
+    if (!expirationDate) return '';
+    return formatTimeLeft(timeLeft);
+  }, [expirationDate, timeLeft]);
+
+  return {
+    expirationDate,
+    isExpired,
+    timeLeft,
+    formattedTimeLeft: formatted,
+  };
+};
+
+export type UseExpirationCountdownReturn = ReturnType<typeof useExpirationCountdown>;

--- a/pages/AgentAgentsPage.tsx
+++ b/pages/AgentAgentsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useData, useSettings, useAuth } from '../App';
 import { Agent, CreditHistoryEntry } from '../types';
 import Card, { CardHeader, CardTitle, CardContent } from '../components/ui/Card';
@@ -6,6 +6,71 @@ import Button from '../components/ui/Button';
 import Modal from '../components/ui/Modal';
 import Input from '../components/ui/Input';
 import { addAgent, updateAgent, deleteAgent } from '../services/firebaseService';
+import { useExpirationCountdown } from '../hooks/useExpirationCountdown';
+
+interface SubAgentForm {
+  username: string;
+  password: string;
+  credits: number;
+  expirationAt: string;
+}
+
+const SubAgentCard: React.FC<{
+  agent: Agent;
+  onAddCredits: (agent: Agent) => void;
+  onEditExpiration: (agent: Agent) => void;
+  onBan: (agent: Agent) => void;
+  onDelete: (agent: Agent) => void;
+}> = ({ agent, onAddCredits, onEditExpiration, onBan, onDelete }) => {
+  const { expirationDate, isExpired, formattedTimeLeft } = useExpirationCountdown(agent.expirationAt);
+  const expirationText = expirationDate ? expirationDate.toLocaleString('th-TH') : 'ไม่มีวันหมดอายุ';
+  const expirationDescription = useMemo(() => {
+    if (!expirationDate) {
+      return 'ไม่มีวันหมดอายุ';
+    }
+    if (isExpired) {
+      return `หมดอายุ: ${expirationText} (บัญชีหมดอายุแล้ว)`;
+    }
+    return `หมดอายุ: ${expirationText} (เหลือเวลา ${formattedTimeLeft})`;
+  }, [expirationDate, expirationText, formattedTimeLeft, isExpired]);
+
+  return (
+    <Card key={agent.id}>
+      <CardHeader className="flex justify-between items-start">
+        <div>
+          <CardTitle className={agent.status === 'banned' ? 'text-red-600' : undefined}>{agent.username}</CardTitle>
+          <p className="text-xs text-slate-400 font-mono mt-1">{agent.id}</p>
+        </div>
+        <div className="text-right">
+          <p className="text-xl font-bold text-blue-600">{agent.credits.toLocaleString()}</p>
+          <p className="text-xs text-slate-500">เครดิต</p>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <p className={`text-xs mb-3 ${isExpired ? 'text-red-600 font-semibold' : 'text-slate-500'}`}>
+          {expirationDescription}
+        </p>
+        <div className="flex flex-col gap-2">
+          <div className="flex gap-2">
+            <Button size="sm" onClick={() => onAddCredits(agent)} className="flex-1">เติมเครดิต</Button>
+            <Button size="sm" variant={agent.status === 'banned' ? 'secondary' : 'danger'} onClick={() => onBan(agent)} className="flex-1">
+              {agent.status === 'banned' ? 'ปลดแบน' : 'แบน'}
+            </Button>
+          </div>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => onEditExpiration(agent)}
+            className="w-full"
+          >
+            {agent.expirationAt ? 'แก้ไขวันหมดอายุ' : 'ตั้งวันหมดอายุ'}
+          </Button>
+          <Button size="sm" variant="danger" onClick={() => onDelete(agent)} className="w-full">ลบ</Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
 
 const AgentAgentsPage: React.FC = () => {
   const { agents, refreshData } = useData();
@@ -15,10 +80,14 @@ const AgentAgentsPage: React.FC = () => {
   const myAgents = agents.filter(a => a.parentId === parent.id);
 
   const [isAddModal, setAddModal] = useState(false);
-  const [newAgent, setNewAgent] = useState({ username: '', password: '', credits: 100 });
+  const [newAgent, setNewAgent] = useState<SubAgentForm>({ username: '', password: '', credits: 100, expirationAt: '' });
   const [selected, setSelected] = useState<Agent | null>(null);
   const [creditsToAdd, setCreditsToAdd] = useState(100);
   const [isCreditModal, setCreditModal] = useState(false);
+  const [isExpirationModal, setExpirationModal] = useState(false);
+  const [agentForExpiration, setAgentForExpiration] = useState<Agent | null>(null);
+  const [expirationValue, setExpirationValue] = useState('');
+  const [expirationError, setExpirationError] = useState('');
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -26,6 +95,19 @@ const AgentAgentsPage: React.FC = () => {
     if (parent.credits < initialCredits) {
       notify('เครดิตไม่พอ', 'error');
       return;
+    }
+    let expirationIso: string | undefined;
+    if (newAgent.expirationAt) {
+      const expirationDate = new Date(newAgent.expirationAt);
+      if (Number.isNaN(expirationDate.getTime())) {
+        notify('รูปแบบวันหมดอายุไม่ถูกต้อง', 'error');
+        return;
+      }
+      if (expirationDate.getTime() <= Date.now()) {
+        notify('วันหมดอายุต้องอยู่ในอนาคต', 'error');
+        return;
+      }
+      expirationIso = expirationDate.toISOString();
     }
     if (!window.confirm(`ยืนยันสร้างตัวแทนนี้และหักเครดิต ${initialCredits}?`)) return;
     const newId = `agent-${Date.now().toString(36)}`;
@@ -53,6 +135,7 @@ const AgentAgentsPage: React.FC = () => {
       creditHistory: [childHistory],
       status: 'active',
       parentId: parent.id,
+      expirationAt: expirationIso,
     });
     const updatedParent: Agent = {
       ...parent,
@@ -63,7 +146,7 @@ const AgentAgentsPage: React.FC = () => {
     updateUserData(updatedParent);
     refreshData();
     setAddModal(false);
-    setNewAgent({ username: '', password: '', credits: 100 });
+    setNewAgent({ username: '', password: '', credits: 100, expirationAt: '' });
     notify('สร้างตัวแทนแล้ว');
   };
 
@@ -71,6 +154,29 @@ const AgentAgentsPage: React.FC = () => {
     setSelected(agent);
     setCreditsToAdd(100);
     setCreditModal(true);
+  };
+
+  const formatDateTimeLocal = (value: string) => {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return '';
+    }
+    const pad = (num: number) => num.toString().padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+  };
+
+  const openExpirationModal = (agent: Agent) => {
+    setAgentForExpiration(agent);
+    setExpirationValue(agent.expirationAt ? formatDateTimeLocal(agent.expirationAt) : '');
+    setExpirationError('');
+    setExpirationModal(true);
+  };
+
+  const closeExpirationModal = () => {
+    setExpirationModal(false);
+    setAgentForExpiration(null);
+    setExpirationError('');
+    setExpirationValue('');
   };
 
   const handleAddCredits = async (e: React.FormEvent) => {
@@ -114,6 +220,32 @@ const AgentAgentsPage: React.FC = () => {
     notify('เติมเครดิตสำเร็จ');
   };
 
+  const handleUpdateExpiration = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!agentForExpiration) return;
+    setExpirationError('');
+
+    let expirationIso: string | undefined;
+    if (expirationValue) {
+      const expirationDate = new Date(expirationValue);
+      if (Number.isNaN(expirationDate.getTime())) {
+        setExpirationError('รูปแบบวันหมดอายุไม่ถูกต้อง');
+        return;
+      }
+      if (expirationDate.getTime() <= Date.now()) {
+        setExpirationError('วันหมดอายุต้องอยู่ในอนาคต');
+        return;
+      }
+      expirationIso = expirationDate.toISOString();
+    }
+
+    const updatedAgent: Agent = { ...agentForExpiration, expirationAt: expirationIso };
+    await updateAgent(updatedAgent);
+    refreshData();
+    closeExpirationModal();
+    notify(expirationIso ? 'บันทึกวันหมดอายุแล้ว' : 'ลบวันหมดอายุแล้ว');
+  };
+
   const handleBan = async (agent: Agent) => {
     const updated = { ...agent, status: agent.status === 'banned' ? 'active' : 'banned' };
     await updateAgent(updated);
@@ -136,26 +268,15 @@ const AgentAgentsPage: React.FC = () => {
       </div>
       {myAgents.length > 0 ? (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {myAgents.map(a => (
-            <Card key={a.id}>
-              <CardHeader className="flex justify-between items-start">
-                <div>
-                  <CardTitle className={a.status === 'banned' ? 'text-red-600' : undefined}>{a.username}</CardTitle>
-                  <p className="text-xs text-slate-400 font-mono mt-1">{a.id}</p>
-                </div>
-                <div className="text-right">
-                  <p className="text-xl font-bold text-blue-600">{a.credits.toLocaleString()}</p>
-                  <p className="text-xs text-slate-500">เครดิต</p>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <div className="flex gap-2 mb-2">
-                  <Button size="sm" onClick={() => openAddCredits(a)} className="flex-1">เติมเครดิต</Button>
-                  <Button size="sm" variant={a.status === 'banned' ? 'secondary' : 'danger'} onClick={() => handleBan(a)} className="flex-1">{a.status === 'banned' ? 'ปลดแบน' : 'แบน'}</Button>
-                </div>
-                <Button size="sm" variant="danger" onClick={() => handleDelete(a)} className="w-full">ลบ</Button>
-              </CardContent>
-            </Card>
+          {myAgents.map(agent => (
+            <SubAgentCard
+              key={agent.id}
+              agent={agent}
+              onAddCredits={openAddCredits}
+              onEditExpiration={openExpirationModal}
+              onBan={handleBan}
+              onDelete={handleDelete}
+            />
           ))}
         </div>
       ) : (
@@ -167,6 +288,7 @@ const AgentAgentsPage: React.FC = () => {
           <Input label="ชื่อผู้ใช้" value={newAgent.username} onChange={e => setNewAgent({ ...newAgent, username: e.target.value })} required />
           <Input label="รหัสผ่าน" type="password" value={newAgent.password} onChange={e => setNewAgent({ ...newAgent, password: e.target.value })} required />
           <Input label="เครดิตเริ่มต้น" type="number" value={newAgent.credits} onChange={e => setNewAgent({ ...newAgent, credits: Number(e.target.value) })} required />
+          <Input label="วันหมดอายุ (ไม่บังคับ)" type="datetime-local" value={newAgent.expirationAt} onChange={e => setNewAgent({ ...newAgent, expirationAt: e.target.value })} />
           <div className="flex justify-end gap-2">
             <Button type="button" variant="secondary" onClick={() => setAddModal(false)}>ยกเลิก</Button>
             <Button type="submit">บันทึก</Button>
@@ -180,6 +302,36 @@ const AgentAgentsPage: React.FC = () => {
           <div className="flex justify-end gap-2">
             <Button type="button" variant="secondary" onClick={() => setCreditModal(false)}>ยกเลิก</Button>
             <Button type="submit">เติม</Button>
+          </div>
+        </form>
+      </Modal>
+
+      <Modal
+        isOpen={isExpirationModal}
+        onClose={closeExpirationModal}
+        title={`กำหนดวันหมดอายุ: ${agentForExpiration?.username ?? ''}`}
+      >
+        <form onSubmit={handleUpdateExpiration} className="space-y-4">
+          <Input
+            label="วันหมดอายุ"
+            type="datetime-local"
+            value={expirationValue}
+            onChange={e => setExpirationValue(e.target.value)}
+          />
+          {expirationError && <p className="text-red-500 text-sm">{expirationError}</p>}
+          <div className="flex flex-col sm:flex-row justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => setExpirationValue('')}
+              className="w-full sm:w-auto"
+            >
+              ลบวันหมดอายุ
+            </Button>
+            <div className="flex gap-2 justify-end w-full sm:w-auto">
+              <Button type="button" variant="secondary" onClick={closeExpirationModal}>ยกเลิก</Button>
+              <Button type="submit">บันทึก</Button>
+            </div>
           </div>
         </form>
       </Modal>

--- a/pages/AgentGenerateKeyPage.tsx
+++ b/pages/AgentGenerateKeyPage.tsx
@@ -7,7 +7,7 @@ import Button from '../components/ui/Button';
 import Card, { CardHeader, CardTitle, CardContent } from '../components/ui/Card';
 import Modal from '../components/ui/Modal';
 import Input from '../components/ui/Input';
-import PlatformTabs from '../components/ui/PlatformTabs';
+import Select from '../components/ui/Select';
 
 const AgentGenerateKeyPage: React.FC = () => {
     const { platforms, refreshData } = useData();
@@ -92,8 +92,7 @@ const AgentGenerateKeyPage: React.FC = () => {
     };
 
     return (
-        <div className="space-y-6">
-            <PlatformTabs platforms={platforms} selected={selectedPlatformId} onSelect={setSelectedPlatformId} />
+    <div className="space-y-6">
             <Card className="max-w-xl">
                 <CardHeader>
                     <CardTitle>{t('generateKeyTitle')}</CardTitle>
@@ -101,6 +100,18 @@ const AgentGenerateKeyPage: React.FC = () => {
                 </CardHeader>
                 <CardContent>
                     <form onSubmit={handleGenerateKey} className="space-y-4">
+                        <Select
+                            label="แพลตฟอร์ม"
+                            value={selectedPlatformId}
+                            onChange={e => setSelectedPlatformId(e.target.value)}
+                            disabled={platforms.length === 0}
+                            required
+                        >
+                            <option value="" disabled>เลือกแพลตฟอร์ม</option>
+                            {platforms.map(platform => (
+                                <option key={platform.id} value={platform.id}>{platform.title}</option>
+                            ))}
+                        </Select>
                         <Input label="โทเค็น (1 เครดิต = 1 โทเค็น)" type="number" value={tokens} onChange={e => setTokens(Number(e.target.value))} required />
                         {error && <p className="text-red-500 text-sm">{error}</p>}
                         <div className="flex justify-end pt-2">

--- a/pages/AgentProfilePage.tsx
+++ b/pages/AgentProfilePage.tsx
@@ -1,12 +1,24 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Card, { CardHeader, CardTitle, CardContent } from '../components/ui/Card';
 import { useAuth, useSettings } from '../App';
 import { Agent } from '../types';
+import { useExpirationCountdown } from '../hooks/useExpirationCountdown';
 
 const AgentProfilePage: React.FC = () => {
   const { user } = useAuth();
   const { t } = useSettings();
   const agent = user?.data as Agent;
+  const { expirationDate, isExpired, formattedTimeLeft } = useExpirationCountdown(agent.expirationAt);
+  const expirationText = useMemo(() => {
+    if (!expirationDate) {
+      return 'บัญชีนี้ไม่มีวันหมดอายุ';
+    }
+    const formattedDate = expirationDate.toLocaleString('th-TH');
+    if (isExpired) {
+      return `บัญชีหมดอายุ: ${formattedDate} (บัญชีหมดอายุแล้ว)`;
+    }
+    return `บัญชีหมดอายุ: ${formattedDate} (เหลือเวลา ${formattedTimeLeft})`;
+  }, [expirationDate, formattedTimeLeft, isExpired]);
   return (
     <div className="space-y-6">
       <Card className="max-w-md mx-auto">
@@ -15,6 +27,9 @@ const AgentProfilePage: React.FC = () => {
         </CardHeader>
         <CardContent>
           <p className="text-slate-600 text-sm">เครดิตคงเหลือ: <span className="font-medium text-blue-600">{agent.credits.toLocaleString()}</span></p>
+          <p className={`text-sm mt-2 ${isExpired ? 'text-red-600 font-semibold' : 'text-slate-500'}`}>
+            {expirationText}
+          </p>
         </CardContent>
       </Card>
     </div>

--- a/pages/GenerateKeyPage.tsx
+++ b/pages/GenerateKeyPage.tsx
@@ -7,7 +7,7 @@ import Button from '../components/ui/Button';
 import Card, { CardHeader, CardTitle, CardContent } from '../components/ui/Card';
 import Modal from '../components/ui/Modal';
 import Input from '../components/ui/Input';
-import PlatformTabs from '../components/ui/PlatformTabs';
+import Select from '../components/ui/Select';
 import { ClipboardIcon, CheckIcon } from '@heroicons/react/24/outline';
 
 const GenerateKeyPage: React.FC = () => {
@@ -72,13 +72,24 @@ const GenerateKeyPage: React.FC = () => {
 
   return (
     <div className="space-y-6">
-      <PlatformTabs platforms={platforms} selected={selectedPlatformId} onSelect={setSelectedPlatformId} />
       <Card className="max-w-xl">
         <CardHeader>
           <CardTitle>สร้างคีย์ใหม่</CardTitle>
         </CardHeader>
         <CardContent>
           <form onSubmit={handleGenerateKey} className="space-y-4">
+            <Select
+              label="แพลตฟอร์ม"
+              value={selectedPlatformId}
+              onChange={e => setSelectedPlatformId(e.target.value)}
+              disabled={platforms.length === 0}
+              required
+            >
+              <option value="" disabled>เลือกแพลตฟอร์ม</option>
+              {platforms.map(platform => (
+                <option key={platform.id} value={platform.id}>{platform.title}</option>
+              ))}
+            </Select>
             <Input label="โทเค็น" type="number" value={tokens} onChange={e => setTokens(Number(e.target.value))} required />
             {error && <p className="text-red-500 text-sm">{error}</p>}
             <div className="flex justify-end pt-2">

--- a/types.ts
+++ b/types.ts
@@ -18,6 +18,7 @@ export interface Agent {
   username: string;
   password?: string;
   credits: number;
+  expirationAt?: string;
   keys?: {
     [platformId: string]: ApiKey[];
   };


### PR DESCRIPTION
## Summary
- let admins adjust or clear an agent's expiration date from the agent list with validation
- allow parent agents to update sub-agent expirations via a dedicated modal in their management view
- share date handling helpers and reset logic so expiration editors open with the current value and clean state
- show live expiration countdowns on agent lists and profiles via a shared countdown hook
- switch the key generation pages to a dropdown platform selector so clicking opens a menu of choices

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c98bf599e4832b8142b1a2b1b57472